### PR TITLE
Add support for creating HSSFWorkbooks

### DIFF
--- a/lib/poi/workbook/workbook.rb
+++ b/lib/poi/workbook/workbook.rb
@@ -31,15 +31,21 @@ module POI
       instance
     end
     
-    def self.create(filename)
-      self.new(filename, nil)
+    def self.create(filename, options={})
+      self.new(filename, nil, options)
     end
     
     attr_reader :filename
 
-    def initialize(filename, io_stream)
+    def initialize(filename, io_stream, options={})
       @filename = filename
-      @workbook = io_stream ? org.apache.poi.ss.usermodel.WorkbookFactory.create(io_stream) : org.apache.poi.xssf.usermodel.XSSFWorkbook.new
+      @workbook = if io_stream
+        org.apache.poi.ss.usermodel.WorkbookFactory.create(io_stream)
+      elsif options[:format] == :hssf
+        org.apache.poi.hssf.usermodel.HSSFWorkbook.new
+      else
+        org.apache.poi.xssf.usermodel.XSSFWorkbook.new
+      end
     end
     
     def formula_evaluator

--- a/spec/workbook_spec.rb
+++ b/spec/workbook_spec.rb
@@ -24,7 +24,22 @@ describe POI::Workbook do
     book.worksheets.size.should == 5
     book.filename.should =~ /spreadsheet.xlsx$/
   end
-  
+
+  it "should create an HSSFWorkbook when passed a :format => :hssf option" do
+    book = POI::Workbook.create('test.xls', :format => :hssf)
+    book.poi_workbook.should be_kind_of(org.apache.poi.hssf.usermodel.HSSFWorkbook)
+  end
+
+  it "should create an XSSFWorkbook when passed a :format => :xssf option" do
+    book = POI::Workbook.create('test.xlsx', :format => :xssf)
+    book.poi_workbook.should be_kind_of(org.apache.poi.xssf.usermodel.XSSFWorkbook)
+  end
+
+  it "should create an XSSFWorkbook by default" do
+    book = POI::Workbook.create('test.xlsx')
+    book.poi_workbook.should be_kind_of(org.apache.poi.xssf.usermodel.XSSFWorkbook)
+  end
+
   it "should return a column of cells by reference" do
     name = TestDataFile.expand_path("various_samples.xlsx")
     book = POI::Workbook.open(name)


### PR DESCRIPTION
This PR adds an option to `Workbook.create` and `Workbook.new` for specifying which format the new workbook should use. It defaults to XSSFWorkbook, so it shouldn't affect any existing code.
