### PR TITLE
Fix boldweight not working with underscore

### DIFF
--- a/lib/poi/workbook/workbook.rb
+++ b/lib/poi/workbook/workbook.rb
@@ -83,7 +83,7 @@ module POI
       set_value( font, :font_height_in_points, options ) do | value |
         value.to_i
       end
-      set_value font, :bold_weight, options, FONT_CONSTANTS
+      set_value font, :boldweight, options, FONT_CONSTANTS
       set_value font, :color, options, INDEXED_COLORS_CONSTANTS do | value |
         value.index
       end


### PR DESCRIPTION
Correct method name is boldweight.

This spec code uses boldweight.
https://github.com/kameeoze/jruby-poi/blob/master/spec/writing_spec.rb#L31